### PR TITLE
Fix problem with themes (e.g. qdarkstyle)

### DIFF
--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -64,6 +64,15 @@ class _GenericRangeSlider(_GenericSlider):
 
         self.setStyleSheet("")
 
+        # Add QSS styles to ensure compatibility with qdarkstyle
+        self.setStyleSheet(
+            """
+            QSlider { background-color: none; }
+            QSlider::add-page:vertical { background: none; border: none; }
+            QRangeSlider { qproperty-barColor: #9FCBFF; }
+            """
+        )
+
     # ###############  New Public API  #######################
 
     def barIsRigid(self) -> bool:


### PR DESCRIPTION
Related to #58

Add QSS styles to ensure compatibility with qdarkstyle.

* Add `QSlider { background-color: none; }` to the QSS styles.
* Add `QSlider::add-page:vertical { background: none; border: none; }` to the QSS styles.
* Add `QRangeSlider { qproperty-barColor: #9FCBFF; }` to the QSS styles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pyapp-kit/superqt/issues/58?shareId=XXXX-XXXX-XXXX-XXXX).